### PR TITLE
Brought tabs more in line with atom dark

### DIFF
--- a/close.svg
+++ b/close.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="8px" height="8px" viewBox="0 0 8 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 39.1 (31720) - http://www.bohemiancoding.com/sketch -->
+    <title>Artboard</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" fill="#000000">
+            <path d="M5.41421365,4.00000009 L8.00710697,6.59289341 L6.59289341,8.00710697 L4.00000009,5.41421365 L1.40710677,8.00710697 L-0.00710679311,6.59289341 L2.58578653,4.00000009 L-0.00710679311,1.40710677 L1.40710677,-0.00710679311 L4.00000009,2.58578653 L6.59289341,-0.00710679311 L8.00710697,1.40710677 L5.41421365,4.00000009 Z" id="Combined-Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/close.svg
+++ b/close.svg
@@ -1,12 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="8px" height="8px" viewBox="0 0 8 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 39.1 (31720) - http://www.bohemiancoding.com/sketch -->
-    <title>Artboard</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Artboard" fill="#000000">
-            <path d="M5.41421365,4.00000009 L8.00710697,6.59289341 L6.59289341,8.00710697 L4.00000009,5.41421365 L1.40710677,8.00710697 L-0.00710679311,6.59289341 L2.58578653,4.00000009 L-0.00710679311,1.40710677 L1.40710677,-0.00710679311 L4.00000009,2.58578653 L6.59289341,-0.00710679311 L8.00710697,1.40710677 L5.41421365,4.00000009 Z" id="Combined-Shape"></path>
-        </g>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="8px" height="8px" viewBox="0 0 8 8">
+  <path d="M5.41421365,4.00000009 L8.00710697,6.59289341 L6.59289341,8.00710697 L4.00000009,5.41421365 L1.40710677,8.00710697 L-0.00710679311,6.59289341 L2.58578653,4.00000009 L-0.00710679311,1.40710677 L1.40710677,-0.00710679311 L4.00000009,2.58578653 L6.59289341,-0.00710679311 L8.00710697,1.40710677 L5.41421365,4.00000009 Z"></path>
 </svg>

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ exports.decorateConfig = config => {
         border-image: linear-gradient(#21252b, #181a1f 1em) 0 0 0 1 stretch;
         border-style: solid;
       }
-      .tab_tab.tab_first {
+      .tab_tab:first-of-type {
         border-width: 0;
       }
       .tab_tab:hover {
@@ -96,7 +96,7 @@ exports.decorateConfig = config => {
         z-index: 1;
         position: absolute;
         top: 0;
-        left: 0;
+        left: -1px;
         bottom: -1px;
         right: 0;
         height: inherit;
@@ -105,6 +105,9 @@ exports.decorateConfig = config => {
         border: 1px solid #181a1f;
         border-bottom-color: ${backgroundColor};
         border-top: 0;
+      }
+      .tab_tab.tab_active:last-of-type::before {
+        border-right-width: 0;
       }
       .tab_tab.tab_active::after {
         opacity: 1;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const colors = [
 ]
 
 exports.decorateConfig = config => {
-  console.log('Hi mom!')
+  console.log('Hi mom!');
 
   return Object.assign({}, config, {
     foregroundColor,
@@ -37,6 +37,7 @@ exports.decorateConfig = config => {
       ${config.termCSS || ''}
       .cursor-node {
         mix-blend-mode: difference;
+        border-left-width: 2px;
       }
     `,
     css: `
@@ -48,15 +49,109 @@ exports.decorateConfig = config => {
       }
       .tabs_list {
         background-color: #21252b !important;
-        border-bottom-color: rgba(0,0,0,.15) !important;
+        border-bottom-color: #181a1f !important;
       }
+      .tab_tab {
+        font-weight: 500;
+        color: rgba(157, 165, 180, 0.6);
+        border-width: 0 0 0 1px;
+        border-image: linear-gradient(#21252b, #181a1f 1em) 0 0 0 1 stretch;
+        border-style: solid;
+      }
+      .tab_tab.tab_first {
+        border-width: 0;
+      }
+      .tab_tab:hover {
+        color: rgba(157, 165, 180, 0.6);
+        transition: none;
+      }
+      .tab_tab::after {
+        content: "";
+        position: absolute;
+        pointer-events: none;
+        top: 0;
+        bottom: -1px;
+        left: 0;
+        width: 2px;
+        height: inherit;
+        background: #528bff;
+        opacity: 0;
+        transition: opacity .16s;
+        z-index: 1;
+      }
+      .tabs_title,
       .tab_tab.tab_active {
         font-weight: 500;
+        color: #d7dae0;
+      }
+      .tab_tab.tab_active {
         background-color: ${backgroundColor};
-        border-color: rgba(0,0,0,.27) !important;
+      }
+      .tab_tab.tab_active,
+      .tab_tab.tab_active + .tab_tab {
+        border-image: linear-gradient(transparent, transparent) 0 0 0 1 stretch;
       }
       .tab_tab.tab_active::before {
+        content: "";
+        z-index: 1;
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: -1px;
+        right: 0;
+        height: inherit;
+        background-image: linear-gradient(rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
+        box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.06);
+        border: 1px solid #181a1f;
         border-bottom-color: ${backgroundColor};
+        border-top: 0;
+      }
+      .tab_tab.tab_active::after {
+        opacity: 1;
+        transition-duration: .32s;
+      }
+      .tab_icon {
+        display: block;
+        background: rgba(157, 165, 180, 0.6);
+        -webkit-mask-image: url('${__dirname}/close.svg');
+        mask-image: url('${__dirname}/close.svg');
+        -webkit-mask-size: 7px;
+        mask-size: 7px;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position-y: center;
+        mask-position-y: center;
+        -webkit-mask-position-x: 8px;
+        mask-position-x: 8px;
+        width: 26px;
+        height: 100%;
+        top: 0;
+        right: 0;
+        transform: scale(0);
+        transition: transform .08s;
+        opacity: 1;
+        border-radius: 0;
+        z-index: 2;
+      }
+      .tab_icon:hover {
+        background: rgba(157, 165, 180, 0.6);
+        opacity: .7;
+      }
+      .tab_tab.tab_active .tab_icon {
+        background: #d7dae0;
+      }
+      .tab_tab.tab_active .tab_icon:hover {
+        background: #d7dae0;
+      }
+      .tab_tab:hover .tab_icon {
+        transform: scale(1);
+        transition-duration: .16s;
+      }
+      .tab_icon svg {
+        display: none;
+      }
+      .tab_icon::after {
+        display: none;
       }
     `
   })


### PR DESCRIPTION
<img width="802" alt="atom dark tabs" src="https://cloud.githubusercontent.com/assets/3854323/17417469/da646ada-5a93-11e6-845f-f564622afd47.png">

* Added blue indicator on the left
* Added slight gradient overlay and inner glow to active tab
* Added gradient separator between each tab
* Added animated close icon that shows on hover

It's pretty much exactly 1 to 1 with the atom dark theme.
